### PR TITLE
Remove 'Dmitrii Kovanikov' from the members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ To email the current members, send an email to mailto:stability-working-group@ch
   - Tom Sydney Kerckhove
   - Viktor Dukhovni
 - Educators
-  - Dmitrii Kovanikov
 - Consultants
   - Trevis Elser
 - Industrial users


### PR DESCRIPTION
Unfortunately, I don't have the capacity to participate in the stability group at the moment and I don't see the ability for me to do so in the upcoming year, so I'm removing myself from the group.

Thanks everyone for their effort!