### PR TITLE
Add a barebones hlint configuration to kickstart discussion.

### DIFF
--- a/hlint/README.md
+++ b/hlint/README.md
@@ -1,0 +1,12 @@
+# Hlint Rules Aiming To Promote Stability
+
+## Wishlist Of Hlint Features
+
+There are some features we do not have access to from hlint, but that would help us write more
+rules.
+
+1. A default typeclass method is overridden.
+
+For example, the `Eq` typeclass has a method, `(/=)`, that is being considered for removal from the
+class. To promote stability, we would like to be able to write a rule that would trigger a warning
+when this method is manually defined. However we cannot, as of this writing, construct such a rule.

--- a/hlint/stability_hlint.yaml
+++ b/hlint/stability_hlint.yaml
@@ -1,0 +1,9 @@
+# Turn off all rules by default so we only include our explicit configuration.
+- ignore: { }
+
+# Turn on restricted module configurations to be warnings.
+- warn: {name: "Avoid restricted module"}
+
+- modules:
+  - {name: Control.Monad.Trans.Error, within: []} # This module is deprecated.
+  - {name: Control.Monad.Trans.List, within: []} # This module is deprecated.


### PR DESCRIPTION
This configuration will default to all of the built-in rules being off and then adds a pair of warnings around already deprecated modules, namely `Control.Monad.Trans.Error` and `Control.Monad.Trans.List`.

The point of this pull request is to have the discussion around what rules we would want _and_ to determine how we would suggest running these rules for projects.